### PR TITLE
[TASK] Avoid PHP deprecation notice: Explicit nullable Type Must be used

### DIFF
--- a/src/Installer/ConfigurationInstaller.php
+++ b/src/Installer/ConfigurationInstaller.php
@@ -27,8 +27,13 @@ class ConfigurationInstaller extends LibraryInstaller
     private $handler;
     private $cache;
 
-    public function __construct(IOInterface $io, Composer $composer, $type = 'project-configuration', Filesystem $filesystem = null, BinaryInstaller $binaryInstaller = null)
-    {
+    public function __construct(
+        IOInterface $io,
+        Composer $composer,
+        $type = 'project-configuration',
+        ?Filesystem $filesystem = null,
+        ?BinaryInstaller $binaryInstaller = null
+    ) {
         parent::__construct($io, $composer, $type, $filesystem, $binaryInstaller);
         $this->handler = [
             'files' => Handler\FileHandler::class,


### PR DESCRIPTION
PHP 8.4 related
Nullable type can be used since PHP 7.1. 
The supported PHP versions in composer.json still match.